### PR TITLE
Add PDF page count processing dialog with user choice

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2762,6 +2762,16 @@ RAG_FILE_MAX_SIZE = PersistentConfig(
     ),
 )
 
+PDF_PAGE_THRESHOLD = PersistentConfig(
+    "PDF_PAGE_THRESHOLD",
+    "rag.pdf_page_threshold",
+    (
+        int(os.environ.get("PDF_PAGE_THRESHOLD"))
+        if os.environ.get("PDF_PAGE_THRESHOLD")
+        else 30
+    ),
+)
+
 FILE_IMAGE_COMPRESSION_WIDTH = PersistentConfig(
     "FILE_IMAGE_COMPRESSION_WIDTH",
     "file.image_compression_width",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -244,6 +244,7 @@ from open_webui.config import (
     RAG_ALLOWED_FILE_EXTENSIONS,
     RAG_FILE_MAX_COUNT,
     RAG_FILE_MAX_SIZE,
+    PDF_PAGE_THRESHOLD,
     FILE_IMAGE_COMPRESSION_WIDTH,
     FILE_IMAGE_COMPRESSION_HEIGHT,
     RAG_OPENAI_API_BASE_URL,
@@ -867,6 +868,7 @@ app.state.config.FILE_MAX_SIZE = RAG_FILE_MAX_SIZE
 app.state.config.FILE_MAX_COUNT = RAG_FILE_MAX_COUNT
 app.state.config.FILE_IMAGE_COMPRESSION_WIDTH = FILE_IMAGE_COMPRESSION_WIDTH
 app.state.config.FILE_IMAGE_COMPRESSION_HEIGHT = FILE_IMAGE_COMPRESSION_HEIGHT
+app.state.config.PDF_PAGE_THRESHOLD = PDF_PAGE_THRESHOLD
 
 
 app.state.config.RAG_FULL_CONTEXT = RAG_FULL_CONTEXT
@@ -1991,6 +1993,8 @@ async def get_app_config(request: Request):
                         "height": app.state.config.FILE_IMAGE_COMPRESSION_HEIGHT,
                     },
                 },
+                "pdf_page_threshold": app.state.config.PDF_PAGE_THRESHOLD,
+                "content_extraction_engine": app.state.config.CONTENT_EXTRACTION_ENGINE,
                 "permissions": {**app.state.config.USER_PERMISSIONS},
                 "google_drive": {
                     "client_id": GOOGLE_DRIVE_CLIENT_ID.value,

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -39,6 +39,9 @@ from open_webui.models.chats import Chats
 from open_webui.models.knowledge import Knowledges
 from open_webui.models.groups import Groups
 
+from pypdf import PdfReader
+from io import BytesIO
+
 
 from open_webui.routers.retrieval import ProcessFileForm, process_file
 from open_webui.routers.audio import transcribe
@@ -54,6 +57,16 @@ from pydantic import BaseModel
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def get_pdf_page_count(file_content: bytes) -> int:
+    """Get the number of pages in a PDF file."""
+    try:
+        pdf_reader = PdfReader(BytesIO(file_content))
+        return len(pdf_reader.pages)
+    except Exception as e:
+        log.error(f"Error reading PDF page count: {e}")
+        return 0
 
 
 ############################
@@ -270,6 +283,11 @@ def upload_file_handler(
             },
         )
 
+        # Get page count for PDFs
+        pdf_page_count = None
+        if file.content_type == "application/pdf":
+            pdf_page_count = get_pdf_page_count(contents)
+
         file_item = Files.insert_new_file(
             user.id,
             FileForm(
@@ -284,6 +302,7 @@ def upload_file_handler(
                         "name": name,
                         "content_type": file.content_type,
                         "size": len(contents),
+                        "page_count": pdf_page_count,
                         "data": file_metadata,
                     },
                 }

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1575,6 +1575,7 @@ class ProcessFileForm(BaseModel):
     file_id: str
     content: Optional[str] = None
     collection_name: Optional[str] = None
+    metadata: Optional[dict] = None
 
 
 @router.post("/process/file")
@@ -1594,6 +1595,20 @@ def process_file(
 
     if file:
         try:
+            # Store processing type from metadata if provided
+            if form_data.metadata and "processing_type" in form_data.metadata:
+                processing_type = form_data.metadata.get("processing_type", "normal")
+                file_metadata = file.meta.get("data", {}) or {}
+                file_metadata["processing_type"] = processing_type
+
+                # Update file metadata in database
+                Files.update_file_meta_by_id(
+                    file.id,
+                    {"data": file_metadata},
+                    db=db
+                )
+
+                log.info(f"Processing file {file.filename} with type: {processing_type}")
 
             collection_name = form_data.collection_name
 

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -405,6 +405,43 @@ export const processWebSearch = async (
 	return res;
 };
 
+export const processFile = async (
+	token: string,
+	body: {
+		file_id: string;
+		collection_name?: string;
+		content?: string;
+		metadata?: Record<string, any>;
+	}
+) => {
+	let error = null;
+
+	const res = await fetch(`${RETRIEVAL_API_BASE_URL}/process/file`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify(body)
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const queryDoc = async (
 	token: string,
 	collection_name: string,

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -50,6 +50,7 @@
 		getWeekday
 	} from '$lib/utils';
 	import { uploadFile } from '$lib/apis/files';
+	import { processFile as processFileAPI } from '$lib/apis/retrieval';
 	import { generateAutoCompletion } from '$lib/apis';
 	import { deleteFileById } from '$lib/apis/files';
 	import { getSessionUser } from '$lib/apis/auths';
@@ -69,6 +70,7 @@
 	import Tooltip from '../common/Tooltip.svelte';
 	import FileItem from '../common/FileItem.svelte';
 	import Image from '../common/Image.svelte';
+	import PDFProcessingOptionsDialog from '../common/PDFProcessingOptionsDialog.svelte';
 
 	import XMark from '../icons/XMark.svelte';
 	import GlobeAlt from '../icons/GlobeAlt.svelte';
@@ -419,6 +421,10 @@
 	let inputFiles;
 
 	let showInputModal = false;
+	let showPDFProcessingDialog = false;
+	let pendingUploadedFileId = null;
+	let pendingPDFPageCount = 0;
+	let pendingPDFFileName = '';
 
 	let dragged = false;
 	let shiftKey = false;
@@ -532,6 +538,65 @@
 		}
 	};
 
+	const processUploadedFile = async (
+		fileId: string,
+		tempItemId: string,
+		processingType: string = 'normal'
+	) => {
+		try {
+			// Find the file item
+			const fileIndex = files.findIndex((f) => f.id === fileId);
+			if (fileIndex === -1) return;
+
+			// Trigger processing via the process file endpoint
+			await processFileAPI(localStorage.token, {
+				file_id: fileId,
+				collection_name: '',
+				metadata: { processing_type: processingType }
+			});
+
+			// Update status to show processing
+			files[fileIndex].status = 'uploaded';
+			files = files;
+		} catch (error) {
+			console.error('Error processing file:', error);
+			toast.error($i18n.t('Failed to process file'));
+		}
+	};
+
+	const handlePDFProcessingChoice = async (event) => {
+		const choice = event.detail.choice;
+		showPDFProcessingDialog = false;
+
+		const fileId = pendingUploadedFileId;
+		const fileIndex = files.findIndex((f) => f.id === fileId);
+
+		// Clear pending state
+		pendingUploadedFileId = null;
+		pendingPDFPageCount = 0;
+		pendingPDFFileName = '';
+
+		// Process the file with user's choice
+		if (fileId && fileIndex !== -1) {
+			await processUploadedFile(fileId, files[fileIndex].itemId, choice);
+		}
+	};
+
+	const handlePDFProcessingCancel = () => {
+		showPDFProcessingDialog = false;
+
+		// Remove the uploaded file since user cancelled
+		const fileId = pendingUploadedFileId;
+		if (fileId) {
+			files = files.filter((f) => f.id !== fileId);
+			// Optionally: could delete file from backend here
+		}
+
+		pendingUploadedFileId = null;
+		pendingPDFPageCount = 0;
+		pendingPDFFileName = '';
+	};
+
 	const uploadFileHandler = async (file, process = true, itemData = {}) => {
 		if ($_user?.role !== 'admin' && !($_user?.permissions?.chat?.file_upload ?? true)) {
 			toast.error($i18n.t('You do not have permission to upload files.'));
@@ -578,19 +643,57 @@
 					};
 				}
 
-				// During the file upload, file content is automatically extracted.
-				const uploadedFile = await uploadFile(localStorage.token, file, metadata, process);
+				// Check if this is a PDF that should show processing choice dialog
+				let shouldCheckPageCount =
+					file.type === 'application/pdf' &&
+					process &&
+					($config?.content_extraction_engine ?? '') === '';
+
+				// If PDF that might need dialog, upload without processing first to get page count
+				const shouldProcess = shouldCheckPageCount ? false : process;
+				const uploadedFile = await uploadFile(localStorage.token, file, metadata, shouldProcess);
 
 				if (uploadedFile) {
 					console.log('File upload completed:', {
 						id: uploadedFile.id,
 						name: fileItem.name,
-						collection: uploadedFile?.meta?.collection_name
+						collection: uploadedFile?.meta?.collection_name,
+						pageCount: uploadedFile.meta?.page_count
 					});
 
 					if (uploadedFile.error) {
 						console.warn('File upload warning:', uploadedFile.error);
 						toast.warning(uploadedFile.error);
+					}
+
+					// Check page count for PDFs
+					if (shouldCheckPageCount && uploadedFile.meta?.page_count) {
+						const pageCount = uploadedFile.meta.page_count;
+						const threshold = $config?.pdf_page_threshold ?? 30;
+
+						if (pageCount > threshold) {
+							// Show dialog - store file info
+							pendingUploadedFileId = uploadedFile.id;
+							pendingPDFPageCount = pageCount;
+							pendingPDFFileName = uploadedFile.filename;
+							showPDFProcessingDialog = true;
+
+							// Update fileItem to show "uploaded, waiting for choice"
+							fileItem.status = 'uploaded';
+							fileItem.file = uploadedFile;
+							fileItem.id = uploadedFile.id;
+							fileItem.collection_name =
+								uploadedFile?.meta?.collection_name || uploadedFile?.collection_name;
+							fileItem.content_type = uploadedFile.meta?.content_type || uploadedFile.content_type;
+							fileItem.url = `${uploadedFile.id}`;
+
+							files = files;
+							return uploadedFile;
+						} else {
+							// Page count below threshold, process normally
+							await processUploadedFile(uploadedFile.id, tempItemId);
+							return uploadedFile;
+						}
 					}
 
 					fileItem.status = 'uploaded';
@@ -1886,3 +1989,11 @@
 		</div>
 	</div>
 {/if}
+
+<PDFProcessingOptionsDialog
+	bind:show={showPDFProcessingDialog}
+	fileName={pendingPDFFileName}
+	pageCount={pendingPDFPageCount}
+	on:select={handlePDFProcessingChoice}
+	on:cancel={handlePDFProcessingCancel}
+/>

--- a/src/lib/components/common/PDFProcessingOptionsDialog.svelte
+++ b/src/lib/components/common/PDFProcessingOptionsDialog.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { onMount, getContext, createEventDispatcher, onDestroy, tick } from 'svelte';
+	import * as FocusTrap from 'focus-trap';
+
+	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher();
+
+	import { fade } from 'svelte/transition';
+	import { flyAndScale } from '$lib/utils/transitions';
+
+	export let show = false;
+	export let fileName = '';
+	export let pageCount = 0;
+
+	let modalElement = null;
+	let mounted = false;
+	let focusTrap: FocusTrap.FocusTrap | null = null;
+
+	const handleChoice = (choice: 'normal' | 'advanced') => {
+		show = false;
+		dispatch('select', { choice });
+	};
+
+	const handleCancel = () => {
+		show = false;
+		dispatch('cancel');
+	};
+
+	const handleKeyDown = (event: KeyboardEvent) => {
+		if (event.key === 'Escape') {
+			handleCancel();
+		}
+	};
+
+	onMount(() => {
+		mounted = true;
+	});
+
+	$: if (mounted) {
+		if (show && modalElement) {
+			document.body.appendChild(modalElement);
+			focusTrap = FocusTrap.createFocusTrap(modalElement);
+			focusTrap.activate();
+
+			window.addEventListener('keydown', handleKeyDown);
+			document.body.style.overflow = 'hidden';
+		} else if (modalElement) {
+			if (focusTrap) {
+				focusTrap.deactivate();
+			}
+
+			window.removeEventListener('keydown', handleKeyDown);
+			if (document.body.contains(modalElement)) {
+				document.body.removeChild(modalElement);
+			}
+
+			document.body.style.overflow = 'unset';
+		}
+	}
+
+	onDestroy(() => {
+		show = false;
+		if (focusTrap) {
+			focusTrap.deactivate();
+		}
+		if (modalElement && document.body.contains(modalElement)) {
+			document.body.removeChild(modalElement);
+		}
+	});
+</script>
+
+{#if show}
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div
+		bind:this={modalElement}
+		class="fixed top-0 right-0 left-0 bottom-0 bg-black/60 w-full h-screen max-h-[100dvh] flex justify-center z-99999999 overflow-hidden overscroll-contain"
+		in:fade={{ duration: 10 }}
+		on:mousedown={handleCancel}
+	>
+		<div
+			class="m-auto max-w-full w-[32rem] mx-2 bg-white/95 dark:bg-gray-950/95 backdrop-blur-sm rounded-4xl max-h-[100dvh] shadow-3xl border border-white dark:border-gray-900"
+			in:flyAndScale
+			on:mousedown={(e) => {
+				e.stopPropagation();
+			}}
+		>
+			<div class="px-[1.75rem] py-6 flex flex-col">
+				<!-- Title -->
+				<div class="text-lg font-medium dark:text-gray-200 mb-2.5">
+					{$i18n.t('Large PDF Detected')}
+				</div>
+
+				<!-- File Info -->
+				<div class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+					<div class="font-medium">{fileName}</div>
+					<div class="text-xs mt-1">
+						{pageCount}
+						{pageCount === 1 ? $i18n.t('page') : $i18n.t('pages')}
+					</div>
+				</div>
+
+				<!-- Message -->
+				<div class="text-sm text-gray-500 dark:text-gray-400 mb-5">
+					{$i18n.t('Choose how to process this PDF file:')}
+				</div>
+
+				<!-- Options -->
+				<div class="flex flex-col gap-3 mb-4">
+					<!-- Fast Processing Button -->
+					<button
+						class="text-left bg-gray-100 hover:bg-gray-200 dark:bg-gray-850 dark:hover:bg-gray-800 rounded-xl p-4 transition"
+						on:click={() => handleChoice('normal')}
+						type="button"
+					>
+						<div class="font-medium text-gray-900 dark:text-gray-100 mb-1">
+							{$i18n.t('Fast Processing')}
+						</div>
+						<div class="text-xs text-gray-600 dark:text-gray-400">
+							{$i18n.t('Standard text extraction. Best for text-only documents.')}
+						</div>
+					</button>
+
+					<!-- Advanced Processing Button -->
+					<button
+						class="text-left bg-blue-50 hover:bg-blue-100 dark:bg-blue-950/50 dark:hover:bg-blue-900/50 border border-blue-200 dark:border-blue-800 rounded-xl p-4 transition"
+						on:click={() => handleChoice('advanced')}
+						type="button"
+					>
+						<div class="font-medium text-gray-900 dark:text-gray-100 mb-1">
+							{$i18n.t('Advanced Processing (Slow)')}
+						</div>
+						<div class="text-xs text-gray-600 dark:text-gray-400">
+							{$i18n.t('Enhanced extraction with images and complex layouts. May take longer.')}
+						</div>
+					</button>
+				</div>
+
+				<!-- Cancel Button -->
+				<button
+					class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 py-2"
+					on:click={handleCancel}
+					type="button"
+				>
+					{$i18n.t('Cancel')}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -33,7 +33,7 @@
 		updateKnowledgeById,
 		searchKnowledgeFilesById
 	} from '$lib/apis/knowledge';
-	import { processWeb, processYoutubeVideo } from '$lib/apis/retrieval';
+	import { processWeb, processYoutubeVideo, processFile as processFileAPI } from '$lib/apis/retrieval';
 
 	import { blobToFile, isYoutubeUrl } from '$lib/utils';
 
@@ -54,6 +54,7 @@
 	import DropdownOptions from '$lib/components/common/DropdownOptions.svelte';
 	import Pagination from '$lib/components/common/Pagination.svelte';
 	import AttachWebpageModal from '$lib/components/chat/MessageInput/AttachWebpageModal.svelte';
+	import PDFProcessingOptionsDialog from '$lib/components/common/PDFProcessingOptionsDialog.svelte';
 
 	let largeScreen = true;
 
@@ -65,6 +66,10 @@
 
 	let showSyncConfirmModal = false;
 	let showAccessControlModal = false;
+	let showPDFProcessingDialog = false;
+	let pendingUploadedFileId = null;
+	let pendingPDFPageCount = 0;
+	let pendingPDFFileName = '';
 
 	let minSize = 0;
 	type Knowledge = {
@@ -247,6 +252,59 @@
 		}
 	};
 
+	const processUploadedFile = async (
+		fileId: string,
+		itemId: string,
+		processingType: string = 'normal'
+	) => {
+		try {
+			// Trigger processing via the process file endpoint
+			await processFileAPI(localStorage.token, {
+				file_id: fileId,
+				collection_name: `knowledge-${knowledge.id}`,
+				metadata: { processing_type: processingType }
+			});
+
+			// After processing, add to knowledge base
+			await addFileHandler(fileId);
+		} catch (error) {
+			console.error('Error processing file:', error);
+			toast.error($i18n.t('Failed to process file'));
+		}
+	};
+
+	const handlePDFProcessingChoice = async (event) => {
+		const choice = event.detail.choice;
+		showPDFProcessingDialog = false;
+
+		const fileId = pendingUploadedFileId;
+		const fileIndex = fileItems.findIndex((f) => f.id === fileId);
+
+		// Clear pending state
+		pendingUploadedFileId = null;
+		pendingPDFPageCount = 0;
+		pendingPDFFileName = '';
+
+		// Process the file with user's choice
+		if (fileId && fileIndex !== -1) {
+			await processUploadedFile(fileId, fileItems[fileIndex].itemId, choice);
+		}
+	};
+
+	const handlePDFProcessingCancel = () => {
+		showPDFProcessingDialog = false;
+
+		// Remove the uploaded file since user cancelled
+		const fileId = pendingUploadedFileId;
+		if (fileId) {
+			fileItems = fileItems.filter((f) => f.id !== fileId);
+		}
+
+		pendingUploadedFileId = null;
+		pendingPDFPageCount = 0;
+		pendingPDFFileName = '';
+	};
+
 	const uploadFileHandler = async (file) => {
 		console.log(file);
 
@@ -296,7 +354,18 @@
 					: {})
 			};
 
-			const uploadedFile = await uploadFile(localStorage.token, file, metadata).catch((e) => {
+			// Check if this is a PDF that should show processing choice dialog
+			let shouldCheckPageCount =
+				file.type === 'application/pdf' && ($config?.content_extraction_engine ?? '') === '';
+
+			// If PDF that might need dialog, upload without processing first to get page count
+			const shouldProcess = shouldCheckPageCount ? false : true;
+			const uploadedFile = await uploadFile(
+				localStorage.token,
+				file,
+				metadata,
+				shouldProcess
+			).catch((e) => {
 				toast.error(`${e}`);
 				return null;
 			});
@@ -314,9 +383,30 @@
 					console.warn('File upload warning:', uploadedFile.error);
 					toast.warning(uploadedFile.error);
 					fileItems = fileItems.filter((file) => file.id !== uploadedFile.id);
-				} else {
-					await addFileHandler(uploadedFile.id);
+					return;
 				}
+
+				// Check page count for PDFs
+				if (shouldCheckPageCount && uploadedFile.meta?.page_count) {
+					const pageCount = uploadedFile.meta.page_count;
+					const threshold = $config?.pdf_page_threshold ?? 30;
+
+					if (pageCount > threshold) {
+						// Show dialog - store file info
+						pendingUploadedFileId = uploadedFile.id;
+						pendingPDFPageCount = pageCount;
+						pendingPDFFileName = uploadedFile.filename;
+						showPDFProcessingDialog = true;
+						return uploadedFile;
+					} else {
+						// Page count below threshold, process and add to knowledge normally
+						await processUploadedFile(uploadedFile.id, fileItem.itemId);
+						return uploadedFile;
+					}
+				}
+
+				// Normal flow for non-PDFs
+				await addFileHandler(uploadedFile.id);
 			} else {
 				toast.error($i18n.t('Failed to upload file.'));
 			}
@@ -1103,3 +1193,11 @@
 		<Spinner className="size-5" />
 	{/if}
 </div>
+
+<PDFProcessingOptionsDialog
+	bind:show={showPDFProcessingDialog}
+	fileName={pendingPDFFileName}
+	pageCount={pendingPDFPageCount}
+	on:select={handlePDFProcessingChoice}
+	on:cancel={handlePDFProcessingCancel}
+/>


### PR DESCRIPTION
## Summary
Adds a feature to check PDF page count on upload and show a dialog for large PDFs, allowing users to choose between fast or advanced processing.

## Features
- 🎯 **Environment variable** `PDF_PAGE_THRESHOLD` (default: 30 pages)
- 📄 **Page count extraction** using pypdf during upload
- 💬 **User-friendly dialog** with two processing options
- ⚡ **Two-phase upload flow**: upload → check pages → show dialog → process
- 💾 **Metadata storage** for processing type (normal vs advanced)
- 🔄 **Works in both contexts**: chat uploads and knowledge base

## Implementation

### Backend
- **config.py**: Add `PDF_PAGE_THRESHOLD` configuration
- **main.py**: Expose config and content_extraction_engine in API
- **routers/files.py**: Extract page count with pypdf, store in `file.meta.page_count`
- **routers/retrieval.py**: Accept and store `processing_type` metadata

### Frontend  
- **PDFProcessingOptionsDialog.svelte**: New accessible modal component
- **MessageInput.svelte**: Two-phase upload logic with dialog
- **KnowledgeBase.svelte**: Same logic for knowledge uploads
- **apis/retrieval/index.ts**: Add `processFile()` API helper

## User Flow
1. User uploads a PDF file (e.g., 50 pages)
2. Backend uploads file and extracts page count
3. If page count > threshold (30) AND using default loader:
   - Frontend shows dialog: "Large PDF Detected - 50 pages"
   - Two options:
     - **Fast Processing**: Standard text extraction
     - **Advanced Processing (Slow)**: Enhanced extraction (future implementation)
4. User selects option → processing starts with metadata
5. Processing type stored in `file.meta.data.processing_type` for future use

## Configuration

Set custom threshold via environment variable:
```bash
export PDF_PAGE_THRESHOLD=50  # Show dialog for PDFs with >50 pages
```

## Testing Checklist
- [ ] Small PDF (<30 pages): No dialog, immediate processing
- [ ] Large PDF (>30 pages): Dialog appears with page count
- [ ] Fast Processing: Stores `processing_type: "normal"`
- [ ] Advanced Processing: Stores `processing_type: "advanced"`
- [ ] Cancel: Removes file from list
- [ ] Works in chat context
- [ ] Works in knowledge base context
- [ ] Only triggers for default loader (not Tika/Mistral)

## Future Work
The `processing_type` metadata is ready for custom processing logic:
- `normal`: Use existing PyPDFLoader
- `advanced`: Send to external endpoint, receive markdown (to be implemented)

## Screenshots
_Dialog shows file name, page count, and two clear processing options with descriptions._

---

🤖 Generated with Claude Code